### PR TITLE
Respecting indentation

### DIFF
--- a/input/src/main/scala/fix/GuardrailScalaResponseTypes.scala
+++ b/input/src/main/scala/fix/GuardrailScalaResponseTypes.scala
@@ -7,6 +7,8 @@ import scala.concurrent.Future
 
 object GuardrailScalaResponseTypes {
   class FooHandlerImpl extends FooHandler {
-    override def doFoo(respond: FooResource.doFooResponse.type)(): Future[FooResource.doFooResponse] = Future.successful(respond.Ok)
+    override def doFoo(respond: FooResource.doFooResponse.type)(): Future[FooResource.doFooResponse] = {
+      Future.successful(respond.Ok)
+    }
   }
 }

--- a/output/src/main/scala/fix/GuardrailScalaResponseTypes.scala
+++ b/output/src/main/scala/fix/GuardrailScalaResponseTypes.scala
@@ -4,6 +4,8 @@ import scala.concurrent.Future
 
 object GuardrailScalaResponseTypes {
   class FooHandlerImpl extends FooHandler {
-    override def doFoo(respond: FooResource.DoFooResponse.type)(): Future[FooResource.DoFooResponse] = Future.successful(respond.Ok)
+    override def doFoo(respond: FooResource.DoFooResponse.type)(): Future[FooResource.DoFooResponse] = {
+      Future.successful(respond.Ok)
+    }
   }
 }

--- a/rules/src/main/scala/fix/GuardrailScalaResponseTypes.scala
+++ b/rules/src/main/scala/fix/GuardrailScalaResponseTypes.scala
@@ -16,28 +16,18 @@ class GuardrailScalaResponseTypes extends SemanticRule("GuardrailScalaResponseTy
         List(Term.Param(
           Nil,
           Term.Name("respond"),
-          Some(Type.Singleton(Term.Select(resourceType, Term.Name(responseType)))), None
+          Some(Type.Singleton(Term.Select(resourceType, responseTypeTree@Term.Name(responseType)))), None
         )) :: otherArgs,
         Some(Type.Apply(
           returnTypeName,
-          List(Type.Select(returnResourceType, Type.Name(returnResponseType)))
+          List(Type.Select(returnResourceType, returnResponseTypeTree@Type.Name(returnResponseType)))
         )),
         _
       ) =>
-        Patch.replaceTree(defn, defn.copy(
-          paramss = List(Term.Param(
-            Nil,
-            Term.Name("respond"),
-            Some(Type.Singleton(Term.Select(
-              resourceType,
-              Term.Name(cap(responseType))
-            ))),
-            None
-          )) :: otherArgs,
-          decltpe = Some(Type.Apply(
-            returnTypeName,
-            List(Type.Select(returnResourceType, Type.Name(cap(returnResponseType))))))
-        ).toString)
-    }).asPatch
+        List(
+          Patch.replaceTree(responseTypeTree, Term.Name(cap(responseType)).toString()),
+          Patch.replaceTree(returnResponseTypeTree, Type.Name(cap(returnResponseType)).toString()),
+        )
+    }).flatten.asPatch
   }
 }


### PR DESCRIPTION
Previously, the entire defn being `.toString()`'d just put the whole method body on the first indentation level. As scalameta doesn't expose whitespace control to the user, we have to constrain our patchset.